### PR TITLE
feat: agregar controladores principales para el sistema

### DIFF
--- a/src/main/java/com/pb/puenteblancovet/controller/AuthController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/AuthController.java
@@ -1,0 +1,73 @@
+package com.puenteblanco.pb.controller;
+
+import com.puenteblanco.pb.dto.request.LoginRequestDto;
+import com.puenteblanco.pb.dto.request.RegisterUserDto;
+import com.puenteblanco.pb.dto.request.RegisterVeterinarianDto;
+import com.puenteblanco.pb.dto.response.LoginResponseDto;
+import com.puenteblanco.pb.services.interfaces.AuthService;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@CrossOrigin 
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register/client")
+    public ResponseEntity<String> registerClient(@RequestBody @Valid RegisterUserDto dto) {
+        authService.registerClient(dto);
+        return ResponseEntity.ok("Cliente registrado exitosamente.");
+    }
+
+    @PostMapping("/register/vet")
+    public ResponseEntity<String> registerVeterinarian(@RequestBody @Valid RegisterVeterinarianDto dto) {
+        authService.registerVeterinarian(dto);
+        return ResponseEntity.ok("Veterinario registrado exitosamente.");
+    }
+
+
+    @PostMapping("/login")
+public ResponseEntity<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto,
+                                              HttpServletResponse response) {
+    LoginResponseDto loginResponse = authService.login(dto); // contiene el token
+
+    // ⬇️ Crea una cookie segura
+    ResponseCookie cookie = ResponseCookie.from("jwt", loginResponse.getToken())
+            .httpOnly(true)
+            .path("/")
+            .maxAge(3600) // 1 hora
+            .sameSite("Lax")
+            .build();
+
+    // ⬇️ Agrega la cookie a la respuesta
+    response.addHeader("Set-Cookie", cookie.toString());
+
+    // ⬇️ Retorna la respuesta al cliente (opcional incluir token o usuario)
+    return ResponseEntity.ok(loginResponse);
+}
+
+@GetMapping("/logout")
+    public String logout(HttpServletResponse response) {
+        Cookie cookie = new Cookie("jwt", "");
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // Expira de inmediato
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // true si usas HTTPS
+        cookie.setDomain("localhost");
+        response.addCookie(cookie);
+
+        return "redirect:/"; // Redirige a login o index.html
+    }
+
+
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/AddAppointmentClientController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/AddAppointmentClientController.java
@@ -1,0 +1,22 @@
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.request.AppointmentRequestDto;
+import com.puenteblanco.pb.services.interfaces.AppointmentClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/client/appointments")
+@RequiredArgsConstructor
+public class AddAppointmentClientController {
+
+    private final AppointmentClientService appointmentClientService;
+
+    @PostMapping
+    public ResponseEntity<String> bookAppointment(@RequestBody AppointmentRequestDto dto, Authentication authentication) {
+        appointmentClientService.bookAppointment(authentication, dto);
+        return ResponseEntity.ok("Cita registrada exitosamente.");
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/AppointmentCancelClientController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/AppointmentCancelClientController.java
@@ -1,0 +1,27 @@
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.response.AppointmentCancelOptionDto;
+import com.puenteblanco.pb.services.interfaces.AppointmentCancelClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/cancel-appointments")
+@RequiredArgsConstructor
+public class AppointmentCancelClientController {
+
+    private final AppointmentCancelClientService appointmentCancelClientService;
+
+    @GetMapping
+    public List<AppointmentCancelOptionDto> getCancelableAppointments(Authentication authentication) {
+        return appointmentCancelClientService.getCancelableAppointments(authentication);
+    }
+
+    @PostMapping("/{id}/cancel")
+    public void cancelAppointment(@PathVariable Long id, Authentication authentication) {
+        appointmentCancelClientService.cancelAppointment(id, authentication);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/AppointmentController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/AppointmentController.java
@@ -1,0 +1,23 @@
+// AppointmentController.java
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.response.AppointmentListResponseDto;
+import com.puenteblanco.pb.services.interfaces.AppointmentShowClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/appointments")
+@RequiredArgsConstructor
+public class AppointmentController {
+
+    private final AppointmentShowClientService appointmentShowClientService;
+
+    @GetMapping
+    public List<AppointmentListResponseDto> getClientAppointments(Authentication auth) {
+        return appointmentShowClientService.getAppointmentsByClient(auth);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/CalendarController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/CalendarController.java
@@ -1,0 +1,23 @@
+// AppointmentController.java
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.response.AppointmentCalendarResponseDto;
+import com.puenteblanco.pb.services.interfaces.AppointmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/appointments")
+@RequiredArgsConstructor
+public class CalendarController {
+
+    private final AppointmentService appointmentService;
+
+    @GetMapping("/calendar")
+    public List<AppointmentCalendarResponseDto> getCalendarAppointments(Authentication authentication) {
+        return appointmentService.getCalendarAppointments(authentication);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/HorarioController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/HorarioController.java
@@ -1,0 +1,24 @@
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.services.interfaces.HorarioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/veterinarians")
+@RequiredArgsConstructor
+public class HorarioController {
+
+    private final HorarioService horarioService;
+
+    @GetMapping("/{id}/horarios")
+    public List<String> getSlotsByDate(
+            @PathVariable Long id,
+            @RequestParam("fecha") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha) {
+        return horarioService.getAvailableTimeSlots(id, fecha);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/PetClientController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/PetClientController.java
@@ -1,0 +1,28 @@
+// File: PetClientController.java
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.entity.Pet;
+import com.puenteblanco.pb.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/pets")
+@RequiredArgsConstructor
+public class PetClientController {
+
+    private final PetRepository petRepository;
+
+    @GetMapping
+    public ResponseEntity<List<Pet>> getPets(Authentication auth) {
+        String email = auth.getName(); // Extraído del token JWT
+        System.out.println("Buscando mascotas para: " + email);
+
+        List<Pet> pets = petRepository.findByOwnerEmail(email);
+        return ResponseEntity.ok(pets);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/PetController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/PetController.java
@@ -1,0 +1,69 @@
+// PetController.java – Controlador para gestionar mascotas de usuario
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.entity.Pet;
+import com.puenteblanco.pb.security.AuthUtils;
+import com.puenteblanco.pb.services.interfaces.PetService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/pets")
+@RequiredArgsConstructor
+public class PetController {
+
+    private final PetService petService;
+
+    // Mostrar formulario para registrar mascota
+    @GetMapping
+    public String showPetForm(Model model) {
+        model.addAttribute("pet", new Pet());
+        return "add-pet";
+    }
+
+    // Registrar nueva mascota (formulario POST)
+    @PostMapping
+    public String registerPet(@ModelAttribute Pet pet) {
+        String email = AuthUtils.getAuthenticatedEmail();
+
+        if (email == null) {
+            throw new RuntimeException("No authenticated user found");
+        }
+
+        pet.setOwnerEmail(email);
+        petService.registerPet(pet);
+
+        return "redirect:/dashboard";
+    }
+
+    // Eliminar lógicamente la mascota por ID
+    @DeleteMapping("/{id}")
+    @ResponseBody
+    public ResponseEntity<?> deletePetById(@PathVariable Long id) {
+        try {
+            petService.deleteById(id); // ahora es lógica (cambia estado a 0)
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("Error al eliminar la mascota.");
+        }
+    }
+
+    // Listar solo mascotas activas para el cliente actual
+    @GetMapping("/actives")
+    @ResponseBody
+    public ResponseEntity<?> getActivePetsForCurrentUser() {
+        String email = AuthUtils.getAuthenticatedEmail();
+        if (email == null) {
+            return ResponseEntity.badRequest().body("Usuario no autenticado");
+        }
+
+        List<Pet> activePets = petService.getActivePetsByOwnerEmail(email);
+        return ResponseEntity.ok(activePets);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/ServiceClientController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/ServiceClientController.java
@@ -1,0 +1,21 @@
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.response.ServiceResponseDto;
+import com.puenteblanco.pb.services.interfaces.ServiceClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/services")
+@RequiredArgsConstructor
+public class ServiceClientController {
+
+    private final ServiceClientService serviceClientService;
+
+    @GetMapping
+    public List<ServiceResponseDto> getAllActiveServices() {
+        return serviceClientService.getAllActiveServices();
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/VaccinationViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/VaccinationViewController.java
@@ -1,0 +1,34 @@
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.view.VaccineDto;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+public class VaccinationViewController {
+
+    @GetMapping("/vaccination")
+    public String showVaccinationPage(Model model) {
+        List<VaccineDto> catVaccines = List.of(
+            new VaccineDto("FVRCP (Rinotraqueítis viral felina, Calicivirus, Panleucopenia)", "6–8 weeks", "3–4 doses", "Cada 3–4 semanas hasta las 16 semanas, luego anualmente", "Vacuna esencial para todos los gatos"),
+            new VaccineDto("Rabia", "12–16 weeks", "1 dose", "Anualmente o cada 3 años (según la vacuna)", "Requerida por ley en la mayoría de zonas"),
+            new VaccineDto("FeLV (Virus de la leucemia felina)", "8–12 weeks", "2 doses", "Refuerzo al año, luego cada 2–3 años", "Recomendado para gatos que salen o en hogares con varios gatos"),
+            new VaccineDto("FIV (Virus de inmunodeficiencia felina)", "8 weeks or older", "3 doses", "Serie inicial, luego según indicación del veterinario", "Opcional, consultar con el veterinario")
+        );
+
+        List<VaccineDto> dogVaccines = List.of(
+            new VaccineDto("DHPP (Moquillo, Hepatitis, Parainfluenza, Parvovirus)", "6–8 semanas", "3–4 dosis", "Cada 3–4 semanas hasta las 16 semanas, luego anualmente o cada 3 años", "Vacuna esencial para todos los perros"),
+            new VaccineDto("Rabia", "12–16 semanas", "1 dosis", "Anualmente o cada 3 años (según la vacuna)", "Requerida por ley en la mayoría de zonas"),
+            new VaccineDto("Bordetella (Tos de las perreras)", "8 semanas", "1–2 dosis", "Cada 6–12 meses para perros en riesgo", "Recomendado para perros que van a guarderías, parques, etc."),
+            new VaccineDto("Leptospirosis", "12 semanas", "2 dosis", "Anualmente", "Recomendado en zonas con alta prevalencia")
+        );
+
+        model.addAttribute("catVaccines", catVaccines);
+        model.addAttribute("dogVaccines", dogVaccines);
+
+        return "vaccination";
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/VeterinarianClientController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/VeterinarianClientController.java
@@ -1,0 +1,24 @@
+// File: VeterinarianClientController.java
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.response.VeterinarianResponseDto;
+import com.puenteblanco.pb.services.interfaces.VeterinarianClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/client/veterinarians")
+@RequiredArgsConstructor
+public class VeterinarianClientController {
+
+    private final VeterinarianClientService veterinarianClientService;
+
+    @GetMapping
+    public ResponseEntity<List<VeterinarianResponseDto>> getAllVeterinarians() {
+        List<VeterinarianResponseDto> veterinarios = veterinarianClientService.getAllVeterinarians();
+        return ResponseEntity.ok(veterinarios);
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/VeterinarianViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/VeterinarianViewController.java
@@ -1,0 +1,23 @@
+package com.puenteblanco.pb.controller.client;
+
+import com.puenteblanco.pb.dto.dashboard.DashboardClientResponseDto;
+import com.puenteblanco.pb.services.interfaces.DashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class VeterinarianViewController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/veterinarians")
+    public String showVeterinarians(Authentication authentication, Model model) {
+        DashboardClientResponseDto dashboard = dashboardService.getClientDashboard(authentication);
+        model.addAttribute("dashboard", dashboard);
+        return "veterinarians"; // nombre del archivo veterinarians.html
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/view/AddAppointmentViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/view/AddAppointmentViewController.java
@@ -1,0 +1,13 @@
+package com.puenteblanco.pb.controller.client.view;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AddAppointmentViewController {
+
+    @GetMapping("/book-appointment")
+    public String renderBookAppointmentPage() {
+        return "book_appointment"; // Thymeleaf busca: templates/book_appointment.html
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/view/AppointmentShowClientViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/view/AppointmentShowClientViewController.java
@@ -1,0 +1,20 @@
+// File: AppointmentClientController.java
+// File: AppointmentShowClientViewController.java
+package com.puenteblanco.pb.controller.client.view;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AppointmentShowClientViewController {
+
+    @GetMapping("/appointments")
+    public String showAppointmentsView(Authentication authentication, Model model) {
+        // Puedes agregar lógica opcional, como pasar el nombre del usuario si deseas mostrarlo en la vista.
+        model.addAttribute("fullName", authentication != null ? authentication.getName() : "Usuario");
+        return "show_appointments"; // El archivo debe estar ubicado en templates/show_appointments.html
+    }
+}
+

--- a/src/main/java/com/pb/puenteblancovet/controller/client/view/CalendarViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/view/CalendarViewController.java
@@ -1,0 +1,25 @@
+package com.puenteblanco.pb.controller.client.view;
+
+import com.puenteblanco.pb.dto.dashboard.DashboardClientResponseDto;
+import com.puenteblanco.pb.services.interfaces.DashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/calendar")
+@RequiredArgsConstructor
+public class CalendarViewController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping
+    public String showCalendar(Model model, Authentication authentication) {
+        DashboardClientResponseDto dashboard = dashboardService.getClientDashboard(authentication);
+        model.addAttribute("dashboard", dashboard);
+        return "calendar"; // Renderiza calendar.html desde /templates
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/view/CancelBookingViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/view/CancelBookingViewController.java
@@ -1,0 +1,22 @@
+package com.puenteblanco.pb.controller.client.view;
+import com.puenteblanco.pb.dto.dashboard.DashboardClientResponseDto;
+import com.puenteblanco.pb.services.interfaces.DashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class CancelBookingViewController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/cancel-appointment")
+    public String showCancelPage(Authentication authentication, Model model) {
+        DashboardClientResponseDto dashboard = dashboardService.getClientDashboard(authentication);
+        model.addAttribute("dashboard", dashboard);
+        return "cancel_booking"; // nombre del archivo HTML sin extensión .html
+    }
+}

--- a/src/main/java/com/pb/puenteblancovet/controller/client/view/DashboardViewController.java
+++ b/src/main/java/com/pb/puenteblancovet/controller/client/view/DashboardViewController.java
@@ -1,0 +1,36 @@
+package com.puenteblanco.pb.controller.client.view;
+
+import com.puenteblanco.pb.dto.dashboard.DashboardClientResponseDto;
+import com.puenteblanco.pb.entity.Pet;
+import com.puenteblanco.pb.repository.PetRepository;
+import com.puenteblanco.pb.security.AuthUtils;
+import com.puenteblanco.pb.services.interfaces.DashboardService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class DashboardViewController {
+
+    private final DashboardService dashboardService;
+    private final PetRepository petRepository;
+
+    @GetMapping("/dashboard")
+    public String showDashboard(Authentication authentication, Model model) {
+        DashboardClientResponseDto dto = dashboardService.getClientDashboard(authentication);
+        model.addAttribute("dashboard", dto);
+
+        String email = AuthUtils.getAuthenticatedEmail();
+        List<Pet> pets = petRepository.findByOwnerEmailAndEstado(email,1);
+        model.addAttribute("pets", pets);
+
+        return "dashboard";
+    }
+}
+


### PR DESCRIPTION
Se agregaron los controladores base que gestionan las operaciones CRUD y las rutas principales para las entidades clave del backend de Puente Blanco. Estos controladores permiten la comunicación entre el frontend y el backend, manejando peticiones HTTP y delegando la lógica de negocio a los servicios correspondientes.